### PR TITLE
009 adding endpoint filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ Then, head to:
 localhost:8081
 ```
 where you can use:
-* /query (to make a new query)
+
+POST
+* /queries (to make a new query)
+
+GET
 * /queries (to get all queries)
 * /queries/_{queryId}_ (to get a specific query)
-* /mentions (get all mentions)
-* /mentions/_{queryId}_ (get all mentions for a query)
+* /mentions (to get all mentions)
+* /mentions/_{queryId}_ (to get all mentions for a query)
 
 ## Built With
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
@@ -1,8 +1,16 @@
 package amcmurray.bw;
 
+import java.util.Date;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 public class Filter {
 
     private String languageCode;
+    @DateTimeFormat(pattern = "dd-MM-yyyy HH:mm:SS")
+    private Date startDate;
+    @DateTimeFormat(pattern = "dd-MM-yyyy HH:mm:SS")
+    private Date endDate;
 
     public String getLanguageCode() {
         return languageCode;
@@ -10,5 +18,21 @@ public class Filter {
 
     public void setLanguageCode(String languageCode) {
         this.languageCode = languageCode;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(Date endDate) {
+        this.endDate = endDate;
     }
 }

--- a/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
@@ -1,0 +1,14 @@
+package amcmurray.bw;
+
+public class Filter {
+
+    private String languageCode;
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public void setLanguageCode(String languageCode) {
+        this.languageCode = languageCode;
+    }
+}

--- a/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
@@ -11,6 +11,7 @@ public class Filter {
     private Date startDate;
     @DateTimeFormat(pattern = "dd-MM-yyyy HH:mm:SS")
     private Date endDate;
+    private String author;
 
     public String getLanguageCode() {
         return languageCode;
@@ -34,5 +35,13 @@ public class Filter {
 
     public void setEndDate(Date endDate) {
         this.endDate = endDate;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
     }
 }

--- a/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/Filter.java
@@ -7,9 +7,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 public class Filter {
 
     private String languageCode;
-    @DateTimeFormat(pattern = "dd-MM-yyyy HH:mm:SS")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Date startDate;
-    @DateTimeFormat(pattern = "dd-MM-yyyy HH:mm:SS")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Date endDate;
     private String author;
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
@@ -16,7 +16,7 @@ import amcmurray.bw.twitterdomainobjects.MentionDTO;
 public class MentionPresenter {
 
     private static final DateTimeFormatter dateFormat
-            = DateTimeFormatter.ofPattern("dd:MM:YYYY HH:mm:ss z Z");
+            = DateTimeFormatter.ofPattern("dd-MM-YYYY HH:mm:ss z Z");
 
     private MentionDTO toDTO(Mention mention) {
         String date = convertDate(mention.getCreatedAt());

--- a/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
@@ -24,7 +24,9 @@ public class MentionPresenter {
         MentionDTO mentionDTO = new MentionDTO(mention.getId(),
                 mention.getQueryId(),
                 mention.getMentionType(),
-                mention.getAuthor(), mention.getText(), date,
+                mention.getAuthor(),
+                mention.getText(),
+                date,
                 mention.getLanguageCode(),
                 mention.getFavouriteCount());
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/MentionPresenter.java
@@ -24,7 +24,7 @@ public class MentionPresenter {
         MentionDTO mentionDTO = new MentionDTO(mention.getId(),
                 mention.getQueryId(),
                 mention.getMentionType(),
-                mention.getText(), date,
+                mention.getAuthor(), mention.getText(), date,
                 mention.getLanguageCode(),
                 mention.getFavouriteCount());
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/QueryRequestDTO.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/QueryRequestDTO.java
@@ -3,13 +3,20 @@ package amcmurray.bw;
 public class QueryRequestDTO {
 
     private String search;
+    private String language;
 
-    public QueryRequestDTO(String search) {
+
+    public QueryRequestDTO(String search, String language) {
         this.search = search;
+        this.language = language;
     }
 
     public String getSearch() {
         return search;
+    }
+
+    public String getLanguage() {
+        return language;
     }
 
     public QueryRequestDTO() {

--- a/minianalytics-api/src/main/java/amcmurray/bw/controllers/MentionsController.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/controllers/MentionsController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import amcmurray.bw.Filter;
 import amcmurray.bw.MentionPresenter;
 import amcmurray.bw.services.MentionService;
 import amcmurray.bw.twitterdomainobjects.MentionDTO;
@@ -30,9 +31,10 @@ public class MentionsController {
      * @return returns a list of MentionDTOs with the same queryId.
      */
     @GetMapping("/mentions/{queryId}")
-    public List<MentionDTO> viewMentionsOfQuery(@PathVariable("queryId") int queryId) {
+    public List<MentionDTO> viewMentionsOfQuery(@PathVariable("queryId") int queryId, Filter filter) {
+
         return mentionPresenter.toDTOs(
-                mentionService.findAllMentionsOfQuery(queryId));
+                mentionService.findAllMentionsOfQueryWithFilters(queryId, filter));
     }
 
     /**

--- a/minianalytics-api/src/main/java/amcmurray/bw/controllers/QueryController.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/controllers/QueryController.java
@@ -27,7 +27,7 @@ public class QueryController {
     /**
      * Create a new query.
      */
-    @PostMapping("/query")
+    @PostMapping("/queries")
     public Query addQuery(@RequestBody QueryRequestDTO request) {
         return queryService.createQuery(request);
     }

--- a/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
@@ -9,4 +9,5 @@ import amcmurray.bw.twitterdomainobjects.Mention;
 public interface MentionRepository extends MongoRepository<Mention, Integer> {
 
     List<Mention> findAllByQueryId(int queryId);
+    List<Mention> findAllByQueryIdAndLanguageCode(int queryId, String languageCode);
 }

--- a/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
@@ -2,12 +2,56 @@ package amcmurray.bw.repositories;
 
 import java.util.List;
 
-import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
 
+import amcmurray.bw.Filter;
 import amcmurray.bw.twitterdomainobjects.Mention;
 
-public interface MentionRepository extends MongoRepository<Mention, Integer> {
+@Repository
+public class MentionRepository {
 
-    List<Mention> findAllByQueryId(int queryId);
-    List<Mention> findAllByQueryIdAndLanguageCode(int queryId, String languageCode);
+    private MongoTemplate mongoTemplate;
+
+    @Autowired
+    public MentionRepository(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public List<Mention> findMentionsOfQueryWithFilters(int queryId, Filter filter) {
+
+        Query dynamicQuery = new Query();
+
+        Criteria idCriteria = Criteria.where("queryId").is(queryId);
+        dynamicQuery.addCriteria(idCriteria);
+
+        if (filter.getLanguageCode() != null) {
+            Criteria languageCodeCriteria = Criteria.where("languageCode").is(filter.getLanguageCode());
+            dynamicQuery.addCriteria(languageCodeCriteria);
+        }
+
+        if (filter.getStartDate() != null && filter.getEndDate() != null) {
+            Criteria rangeCriteria = Criteria.where("createdAt").gte(filter.getStartDate()).lte((filter.getEndDate()));
+
+            dynamicQuery.addCriteria(rangeCriteria);
+        } else if (filter.getStartDate() != null) {
+            Criteria rangeCriteria = Criteria.where("createdAt").gte(filter.getStartDate());
+            dynamicQuery.addCriteria(rangeCriteria);
+
+        } else if (filter.getEndDate() != null) {
+            Criteria rangeCriteria = Criteria.where("createdAt").lte(filter.getEndDate());
+            dynamicQuery.addCriteria(rangeCriteria);
+        }
+
+        return mongoTemplate.find(dynamicQuery, Mention.class, "savedMentions");
+
+    }
+
+    public List<Mention> findAllMentions() {
+        return mongoTemplate.findAll(Mention.class, "savedMentions");
+    }
+
 }

--- a/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/repositories/MentionRepository.java
@@ -33,10 +33,16 @@ public class MentionRepository {
             dynamicQuery.addCriteria(languageCodeCriteria);
         }
 
-        if (filter.getStartDate() != null && filter.getEndDate() != null) {
-            Criteria rangeCriteria = Criteria.where("createdAt").gte(filter.getStartDate()).lte((filter.getEndDate()));
+        //if the date range is valid, filter between
+        //else get after start date or before end date
+        if (filter.getStartDate() != null && filter.getEndDate() != null
+                && filter.getStartDate().compareTo(filter.getEndDate()) < 0) {
 
+            Criteria rangeCriteria = Criteria.where("createdAt")
+                    .gte(filter.getStartDate())
+                    .lte((filter.getEndDate()));
             dynamicQuery.addCriteria(rangeCriteria);
+
         } else if (filter.getStartDate() != null) {
             Criteria rangeCriteria = Criteria.where("createdAt").gte(filter.getStartDate());
             dynamicQuery.addCriteria(rangeCriteria);
@@ -46,8 +52,12 @@ public class MentionRepository {
             dynamicQuery.addCriteria(rangeCriteria);
         }
 
-        return mongoTemplate.find(dynamicQuery, Mention.class, "savedMentions");
+        if (filter.getAuthor() != null) {
+            Criteria authorCriteria = Criteria.where("author").is(filter.getAuthor());
+            dynamicQuery.addCriteria(authorCriteria);
+        }
 
+        return mongoTemplate.find(dynamicQuery, Mention.class, "savedMentions");
     }
 
     public List<Mention> findAllMentions() {

--- a/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
@@ -1,5 +1,6 @@
 package amcmurray.bw.services;
 
+import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -25,19 +26,17 @@ public class MentionService {
     /**
      * If a query is returned, find all mentions of the queryId
      *
+     * @param filter filter object for endpoints
      * @return list of mentions
      * @throws {QueryNotFoundException} if query not found
      */
     public List<Mention> findAllMentionsOfQueryWithFilters(int queryId, Filter filter) {
         queryService.findQueryById(queryId);
 
-        if (StringUtils.isNotBlank(filter.getLanguageCode())) {
-            return mentionRepository.findAllByQueryIdAndLanguageCode(queryId, filter.getLanguageCode());
-        }
-        return mentionRepository.findAllByQueryId(queryId);
+        return mentionRepository.findMentionsOfQueryWithFilters(queryId, filter);
     }
 
     public List<Mention> getAllMentions() {
-        return mentionRepository.findAll();
+        return mentionRepository.findAllMentions();
     }
 }

--- a/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
@@ -1,9 +1,7 @@
 package amcmurray.bw.services;
 
-import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/services/MentionService.java
@@ -2,9 +2,11 @@ package amcmurray.bw.services;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import amcmurray.bw.Filter;
 import amcmurray.bw.repositories.MentionRepository;
 import amcmurray.bw.twitterdomainobjects.Mention;
 
@@ -26,10 +28,12 @@ public class MentionService {
      * @return list of mentions
      * @throws {QueryNotFoundException} if query not found
      */
-    public List<Mention> findAllMentionsOfQuery(int queryId) {
-
+    public List<Mention> findAllMentionsOfQueryWithFilters(int queryId, Filter filter) {
         queryService.findQueryById(queryId);
 
+        if (StringUtils.isNotBlank(filter.getLanguageCode())) {
+            return mentionRepository.findAllByQueryIdAndLanguageCode(queryId, filter.getLanguageCode());
+        }
         return mentionRepository.findAllByQueryId(queryId);
     }
 

--- a/minianalytics-api/src/main/java/amcmurray/bw/services/QueryService.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/services/QueryService.java
@@ -32,7 +32,7 @@ public class QueryService {
         if (StringUtils.isBlank(request.getSearch())) {
             throw new QueryExceptions.QuerySearchNullException();
         } else {
-            Query query = new Query(getNewQueryId(), request.getSearch());
+            Query query = new Query(getNewQueryId(), request.getSearch(), request.getLanguage());
             return queryRepository.save(query);
         }
     }

--- a/minianalytics-api/src/main/java/amcmurray/bw/services/QueryService.java
+++ b/minianalytics-api/src/main/java/amcmurray/bw/services/QueryService.java
@@ -2,6 +2,7 @@ package amcmurray.bw.services;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,7 +11,6 @@ import amcmurray.bw.exceptions.QueryExceptions;
 import amcmurray.bw.repositories.QueryRepository;
 import amcmurray.bw.twitterdomainobjects.Query;
 
-import org.apache.commons.lang3.StringUtils;
 @Service
 public class QueryService {
 

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -53,8 +53,8 @@ public class miniananalyticsApiIT {
             .ofInstant(testDate.toInstant(), ZoneId.of("UTC"))
             .format(DateTimeFormatter.ofPattern("dd:MM:YYYY HH:mm:ss z Z"));
 
-    private final Query query1 = new Query(0, "test query");
-    private final Query query2 = new Query(1, "another search");
+    private final Query query1 = new Query(0, "test query", "en");
+    private final Query query2 = new Query(1, "another search", "");
 
     private final Mention mention1 = new Mention("123abc", 0, MentionType.TWITTER,
             "this is a mention of a test query", testDate, "en", 0);
@@ -140,7 +140,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void addNewQuery_returnsExpectedQuery() {
-        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("new search");
+        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("new search", "en");
 
         with().contentType(ContentType.JSON)
                 .body(queryRequestDTO)
@@ -155,7 +155,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void addNewQueryWithBlankSearch_throwsQuerySearchNullException() {
-        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("");
+        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("", "en");
 
         with().contentType(ContentType.JSON)
                 .body(queryRequestDTO)

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -48,10 +48,10 @@ public class miniananalyticsApiIT {
     private static final String DATABASE_NAME = "minianalytics";
     private static Datastore datastore;
 
-    private final Date testDate1 = Timestamp.valueOf(LocalDateTime.parse("2018.08.31.18.30.00",
-            DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm.ss")));
-    private final Date testDate2 = Timestamp.valueOf(LocalDateTime.parse("2018.08.31.13.45.00",
-            DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm.ss")));
+    private final Date testDate1 = Timestamp.valueOf(LocalDateTime.parse("2018-08-31T18:30:00.000",
+            DateTimeFormatter.ISO_DATE_TIME));
+    private final Date testDate2 = Timestamp.valueOf(LocalDateTime.parse("2018-08-31T13:45:00.000",
+            DateTimeFormatter.ISO_DATE_TIME));
     private final String testDateMentionDTO = ZonedDateTime
             .ofInstant(testDate1.toInstant(), ZoneId.of("UTC"))
             .format(DateTimeFormatter.ofPattern("dd-MM-YYYY HH:mm:ss z Z"));
@@ -199,7 +199,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void viewMentionsOfQueryByIdWithDateBefore_returnsValidMentions() {
-        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?endDate=01-09-2018 12:30:00")
+        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?endDate=2018-09-01T12:30:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -212,7 +212,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void viewMentionsOfQueryByIdWithDateBeforeAndLanguageCode_returnsValidMentions() {
-        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?languageCode=en&endDate=01-09-2018 12:30:00")
+        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?languageCode=en&endDate=2018-09-01T12:30:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -223,7 +223,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void viewMentionsOfQueryByIdWithDateAfter_returnsValidMentions() {
-        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?startDate=31-08-2018 16:00:00")
+        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?startDate=2018-08-31T16:00:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -234,7 +234,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void viewMentionsOfQueryByIdWithDateAfterAndLanguageCode_returnsValidMentions() {
-        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?languageCode=en&startDate=31-08-2018 16:00:00")
+        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?languageCode=en&startDate=2018-08-30T16:00:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -246,7 +246,7 @@ public class miniananalyticsApiIT {
     @Test
     public void viewMentionsOfQueryByIdWithDateRange_returnsValidMentions() {
         with().get(createURLWithPort("/mentions/") + query2.getId()
-                + "/?startDate=30-08-2018 10:30:00&endDate=01-09-2018 12:00:00")
+                + "/?startDate=2018-08-30T10:30:00.000-0000&endDate=2018-09-01T12:00:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -260,7 +260,7 @@ public class miniananalyticsApiIT {
     @Test
     public void viewMentionsOfQueryByIdWithDateRangeAndLanguageFilter_returnsValidMentions() {
         with().get(createURLWithPort("/mentions/") + query2.getId()
-                + "/?languageCode=en&startDate=30-08-2018 10:30:00&endDate=01-09-2018 12:00:00")
+                + "/?languageCode=en&startDate=2018-08-30T10:30:00.000-0000&endDate=2018-09-01T12:00:00.000-0000")
 
                 .then().assertThat()
                 .statusCode(200)
@@ -271,8 +271,8 @@ public class miniananalyticsApiIT {
 
     @Test
     public void viewMentionsOfQueryByIdWithAuthorFilter_returnsValidMentions() {
-        with().get(createURLWithPort("/mentions/") + query2.getId()
-                + "/?author=testAuthor2")
+        with().get(createURLWithPort("/mentions/") + query2.getId()+"/?author=testAuthor2")
+
                 .then().assertThat()
                 .statusCode(200)
                 .body("id", hasSize(1))

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -141,7 +141,7 @@ public class miniananalyticsApiIT {
 
     @Test
     public void addNewQuery_returnsExpectedQuery() {
-        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("new search", "en");
+        QueryRequestDTO queryRequestDTO = new QueryRequestDTO("new search", "pl");
 
         with().contentType(ContentType.JSON)
                 .body(queryRequestDTO)
@@ -151,7 +151,8 @@ public class miniananalyticsApiIT {
                 .then().assertThat()
                 .statusCode(200)
                 .body("id", equalTo(query2.getId() + 1))
-                .body("text", equalTo(queryRequestDTO.getSearch()));
+                .body("text", equalTo(queryRequestDTO.getSearch()))
+                .body("language", equalTo(queryRequestDTO.getLanguage()));
     }
 
     @Test
@@ -193,7 +194,7 @@ public class miniananalyticsApiIT {
                 .body("id", hasSize(1))
                 .body("id[0]", equalTo(mention3.getId()))
                 .body("queryId[0]", equalTo(query2.getId()))
-                .body("languageCode[0]", equalTo(mention3.getLanguageCode()));
+                .body("languageCode[0]", equalTo("de"));
     }
 
     @Test

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -60,11 +60,11 @@ public class miniananalyticsApiIT {
     private final Query query2 = new Query(1, "another search", "");
 
     private final Mention mention1 = new Mention("123abc", 0, MentionType.TWITTER,
-            "this is a mention of a test query", testDate1, "en", 0);
+            "testAuthor1", "this is a mention of a test query", testDate1, "en", 0);
     private final Mention mention2 = new Mention("456def", 1, MentionType.TWITTER,
-            "this is a mention of another search", testDate1, "en", 0);
+            "testAuthor2", "this is a mention of another search", testDate1, "en", 0);
     private final Mention mention3 = new Mention("789hij", 1, MentionType.TWITTER,
-            "eine test Suche", testDate2, "de", 0);
+            "testAuthor1", "eine test Suche", testDate2, "de", 0);
 
     @ClassRule
     public static DockerComposeRule docker = DockerComposeRule.builder()
@@ -261,6 +261,17 @@ public class miniananalyticsApiIT {
         with().get(createURLWithPort("/mentions/") + query2.getId()
                 + "/?languageCode=en&startDate=30-08-2018 10:30:00&endDate=01-09-2018 12:00:00")
 
+                .then().assertThat()
+                .statusCode(200)
+                .body("id", hasSize(1))
+                .body("id[0]", equalTo(mention2.getId()))
+                .body("queryId[0]", equalTo(query2.getId()));
+    }
+
+    @Test
+    public void viewMentionsOfQueryByIdWithAuthorFilter_returnsValidMentions() {
+        with().get(createURLWithPort("/mentions/") + query2.getId()
+                + "/?author=testAuthor2")
                 .then().assertThat()
                 .statusCode(200)
                 .body("id", hasSize(1))

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -61,7 +61,7 @@ public class miniananalyticsApiIT {
     private final Mention mention2 = new Mention("456def", 1, MentionType.TWITTER,
             "this is a mention of another search", testDate, "en", 0);
     private final Mention mention3 = new Mention("789hij", 1, MentionType.TWITTER,
-            "this is a mention of another  search", testDate, "en", 0);
+            "eine test Suche", testDate, "de", 0);
 
 
     @ClassRule
@@ -182,6 +182,20 @@ public class miniananalyticsApiIT {
                 .body("languageCode[0]", equalTo(mention1.getLanguageCode()))
                 .body("favouriteCount[0]", equalTo(mention1.getFavouriteCount()));
     }
+
+
+    @Test
+    public void viewMentionsOfQueryByIdWithLanguageCodeFilter_returnsValidMentions() {
+        with().get(createURLWithPort("/mentions/") + query2.getId() + "/?languageCode=de")
+
+                .then().assertThat()
+                .statusCode(200)
+                .body("id", hasSize(1))
+                .body("id[0]", equalTo(mention3.getId()))
+                .body("queryId[0]", equalTo(query2.getId()))
+                .body("languageCode[0]", equalTo(mention3.getLanguageCode()));
+    }
+
 
     @Test
     public void viewAllMentions_returnsValidMentions() {

--- a/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/integrationTests/miniananalyticsApiIT.java
@@ -145,7 +145,7 @@ public class miniananalyticsApiIT {
         with().contentType(ContentType.JSON)
                 .body(queryRequestDTO)
                 .when()
-                .post((createURLWithPort("/query")))
+                .post((createURLWithPort("/queries")))
 
                 .then().assertThat()
                 .statusCode(200)
@@ -160,7 +160,7 @@ public class miniananalyticsApiIT {
         with().contentType(ContentType.JSON)
                 .body(queryRequestDTO)
                 .when()
-                .post((createURLWithPort("/query")))
+                .post((createURLWithPort("/queries")))
 
                 .then().assertThat()
                 .statusCode(400)

--- a/minianalytics-api/src/test/java/amcmurray/bw/unitTests/MentionPresenterTest.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/unitTests/MentionPresenterTest.java
@@ -32,7 +32,7 @@ public class MentionPresenterTest {
     private final String expectedText = "mocktext";
     private final String expectedTestDate = ZonedDateTime.ofInstant(
             testDate.toInstant(), ZoneId.of("UTC"))
-            .format(DateTimeFormatter.ofPattern("dd:MM:YYYY HH:mm:ss z Z"));
+            .format(DateTimeFormatter.ofPattern("dd-MM-YYYY HH:mm:ss z Z"));
     private final String expectedLanguage = "en";
     private final int expectedFavourites = 0;
 

--- a/minianalytics-api/src/test/java/amcmurray/bw/unitTests/MentionPresenterTest.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/unitTests/MentionPresenterTest.java
@@ -29,6 +29,7 @@ public class MentionPresenterTest {
     private final String expectedId = "123";
     private final int expectedQueryId = 456;
     private final MentionType expectedMentionType = MentionType.TWITTER;
+    private final String expectedAuthor = "testAuthor";
     private final String expectedText = "mocktext";
     private final String expectedTestDate = ZonedDateTime.ofInstant(
             testDate.toInstant(), ZoneId.of("UTC"))
@@ -39,12 +40,12 @@ public class MentionPresenterTest {
 
     private final Mention mention = new Mention(
             expectedId, expectedQueryId, expectedMentionType,
-            expectedText, testDate,
+            expectedAuthor, expectedText, testDate,
             expectedLanguage, expectedFavourites);
 
     private final MentionDTO mentionDto = new MentionDTO(
             expectedId, expectedQueryId, expectedMentionType,
-            expectedText, expectedTestDate,
+            expectedAuthor, expectedText, expectedTestDate,
             expectedLanguage, expectedFavourites);
 
     private final List<Mention> listOfMentions = Arrays.asList(mention,

--- a/minianalytics-api/src/test/java/amcmurray/bw/unitTests/QueryServiceTest.java
+++ b/minianalytics-api/src/test/java/amcmurray/bw/unitTests/QueryServiceTest.java
@@ -25,14 +25,14 @@ public class QueryServiceTest {
     @InjectMocks
     private QueryService queryService;
 
-    private final QueryRequestDTO testQueryDTO = new QueryRequestDTO("test");
-    private final Query testQuery = new Query(12345, "test");
+    private final QueryRequestDTO testQueryDTO = new QueryRequestDTO("test", "en");
+    private final Query testQuery = new Query(12345, "test", "en");
 
 
     @Test
     public void createQuery_createsExpectedQuery() {
         //create a query with the same text as DTO, and a random ID.
-        Query expectedQuery = new Query(56789, testQueryDTO.getSearch());
+        Query expectedQuery = new Query(56789, testQueryDTO.getSearch(), "en");
 
         when(queryRepository.save(any(Query.class))).thenReturn(expectedQuery);
 
@@ -57,7 +57,7 @@ public class QueryServiceTest {
     @Test(expected = QueryExceptions.QuerySearchNullException.class)
     public void blankQueryDTOSearchField_throwsQuerySearchNullException() {
 
-        QueryRequestDTO nullQuery = new QueryRequestDTO("");
+        QueryRequestDTO nullQuery = new QueryRequestDTO("", "en");
         queryService.createQuery(nullQuery);
     }
 

--- a/twitter-crawler/pom.xml
+++ b/twitter-crawler/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
 
         <dependency>
             <groupId>amcmurray.bw</groupId>

--- a/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
+++ b/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
@@ -33,7 +33,6 @@ public class MentionService {
     public void saveNewMentions(Query query) {
 
         SearchParameters params = new SearchParameters(query.getText());
-        params.lang("en"); //english for now
         SearchResults rawSearch = twitter.searchOperations().search(params);
 
         for (Tweet tweet : rawSearch.getTweets()) {

--- a/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
+++ b/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
@@ -47,7 +47,7 @@ public class MentionService {
         for (Tweet tweet : rawSearch.getTweets()) {
             Mention mention = new Mention(UUID.randomUUID().toString(),
                     query.getId(), MentionType.TWITTER,
-                    tweet.getText(), tweet.getCreatedAt(),
+                    tweet.getUser().getScreenName(), tweet.getText(), tweet.getCreatedAt(),
                     tweet.getLanguageCode(), tweet.getFavoriteCount());
             mentionRepository.insert(mention);
         }

--- a/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
+++ b/twitter-crawler/src/main/java/amcmurray/bw/twittercrawler/MentionService.java
@@ -2,6 +2,7 @@ package amcmurray.bw.twittercrawler;
 
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.social.twitter.api.SearchParameters;
 import org.springframework.social.twitter.api.SearchResults;
@@ -33,7 +34,15 @@ public class MentionService {
     public void saveNewMentions(Query query) {
 
         SearchParameters params = new SearchParameters(query.getText());
+
+        //if query has a specified language, set to that
+        if (StringUtils.isNotBlank(query.getLanguage())) {
+            params.lang(query.getLanguage());
+        }
+        params.count(10);
+
         SearchResults rawSearch = twitter.searchOperations().search(params);
+
 
         for (Tweet tweet : rawSearch.getTweets()) {
             Mention mention = new Mention(UUID.randomUUID().toString(),

--- a/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
+++ b/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
@@ -5,17 +5,21 @@ import java.util.Objects;
 
 import org.mongodb.morphia.annotations.Entity;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Entity("savedMentions")
 @Document(collection = "savedMentions")
+@CompoundIndexes({
+        @CompoundIndex(name = "mentionId_queryId", def = "{'id' : 1, 'queryId': 1}")
+})
 public class Mention {
 
     @Id
     @org.mongodb.morphia.annotations.Id
     private String id;
-    @Indexed
     private int queryId;
     private MentionType mentionType;
     private String text;

--- a/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
+++ b/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
@@ -6,15 +6,11 @@ import java.util.Objects;
 import org.mongodb.morphia.annotations.Entity;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Entity("savedMentions")
+@CompoundIndex(name = "mentionId", def = "{'id' : 1, 'queryId': 1}")
 @Document(collection = "savedMentions")
-@CompoundIndexes({
-        @CompoundIndex(name = "mentionId_queryId", def = "{'id' : 1, 'queryId': 1}")
-})
 public class Mention {
 
     @Id

--- a/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
+++ b/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Mention.java
@@ -18,17 +18,19 @@ public class Mention {
     private String id;
     private int queryId;
     private MentionType mentionType;
+    private String author;
     private String text;
     private Date createdAt;
     private String languageCode;
     private int favouriteCount;
 
     public Mention(String id, int queryId, MentionType mentionType,
-                   String text, Date createdAt,
+                   String author, String text, Date createdAt,
                    String languageCode, int favouriteCount) {
         this.id = id;
         this.queryId = queryId;
         this.mentionType = mentionType;
+        this.author = author;
         this.text = text;
         this.createdAt = createdAt;
         this.languageCode = languageCode;
@@ -65,6 +67,10 @@ public class Mention {
 
     public MentionType getMentionType() {
         return mentionType;
+    }
+
+    public String getAuthor() {
+        return author;
     }
 
     public String getText() {

--- a/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/MentionDTO.java
+++ b/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/MentionDTO.java
@@ -7,17 +7,19 @@ public class MentionDTO {
     private String id;
     private int queryId;
     private MentionType mentionType;
+    private String author;
     private String text;
     private String dateCreated;
     private String languageCode;
     private int favouriteCount;
 
     public MentionDTO(String id, int queryId, MentionType mentionType,
-                      String text, String dateCreated,
+                      String author, String text, String dateCreated,
                       String languageCode, int favouriteCount) {
         this.id = id;
         this.queryId = queryId;
         this.mentionType = mentionType;
+        this.author = author;
         this.dateCreated = dateCreated;
         this.text = text;
         this.languageCode = languageCode;
@@ -58,6 +60,10 @@ public class MentionDTO {
 
     public MentionType getMentionType() {
         return mentionType;
+    }
+
+    public String getAuthor() {
+        return author;
     }
 
     public String getText() {

--- a/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Query.java
+++ b/twitter-domain-objects/src/main/java/amcmurray/bw/twitterdomainobjects/Query.java
@@ -14,10 +14,12 @@ public final class Query {
     @org.mongodb.morphia.annotations.Id
     private int id;
     private String text;
+    private String language;
 
-    public Query(int id, String text) {
+    public Query(int id, String text, String language) {
         this.id = id;
         this.text = text;
+        this.language = language;
     }
 
     @Override
@@ -41,5 +43,9 @@ public final class Query {
 
     public String getText() {
         return text;
+    }
+
+    public String getLanguage() {
+        return language;
     }
 }


### PR DESCRIPTION
Added a filter class to allow filtering of mentions. Currently language, date and author are supported. 
MentionRepository has been rewritten to allow dynamic query creation (eg multiple combinations of the previous filter variables). 
Queries now support language when searching for a term. 
More ITs added.